### PR TITLE
EventHandler for full protection of item frames and paintings

### DIFF
--- a/src/main/java/com/mcmiddleearth/freebuild/Protection.java
+++ b/src/main/java/com/mcmiddleearth/freebuild/Protection.java
@@ -281,14 +281,14 @@ public final class Protection implements Listener{
     }
     
     @EventHandler
-    public void onItemFrameRotate(PlayerInteractEntityEvent e)
+    public void onHangingInteract(PlayerInteractEntityEvent e)
     {
         if(DBmanager.curr == null || !e.getRightClicked().getWorld().getName().equals(DBmanager.curr.getCent().getWorld().getName())){
             return;
         }
         Player p = e.getPlayer();
         
-        if(e.getRightClicked() instanceof ItemFrame) {
+        if(e.getRightClicked() instanceof Painting || e.getRightClicked() instanceof ItemFrame) {
             blockPlaceProtect(p.getWorld().getBlockAt(e.getRightClicked().getLocation()),p,e);
         }
     }


### PR DESCRIPTION
Fixed bug in EventHandler onHangingBreak (Permission was calculated from the last clicked blocked instead of entity location)
Added three EventHandler for full protection of Paintings and ItemFrames

Also added cancelling of PlayerInteractEvents with special plant items in hand (displayName = "Placeable..." This will used by Architect plugin to place those plants only in own plots.