### PR TITLE
Update for integration with Architect plugin

### DIFF
--- a/src/main/java/com/mcmiddleearth/freebuild/Protection.java
+++ b/src/main/java/com/mcmiddleearth/freebuild/Protection.java
@@ -281,14 +281,14 @@ public final class Protection implements Listener{
     }
     
     @EventHandler
-    public void onItemFrameRotate(PlayerInteractEntityEvent e)
+    public void onHangingInteract(PlayerInteractEntityEvent e)
     {
         if(DBmanager.curr == null || !e.getRightClicked().getWorld().getName().equals(DBmanager.curr.getCent().getWorld().getName())){
             return;
         }
         Player p = e.getPlayer();
         
-        if(e.getRightClicked() instanceof ItemFrame) {
+        if(e.getRightClicked() instanceof Painting || e.getRightClicked() instanceof ItemFrame) {
             blockPlaceProtect(p.getWorld().getBlockAt(e.getRightClicked().getLocation()),p,e);
         }
     }


### PR DESCRIPTION
For now I told q to diable Architect features in Themed-builds world.

If we want to use Architect plugin features in Themed-builds, Architect plugin will need information about build permission of players in themed-builds. 

I think this can easily be achieved by adding ExternalPermissionHandlers which can be used in TheGaffer plugin. Achitect plugin already hooks into TheGaffer for build permission during jobs and plotbuild. 

These ExternalPermissionHandlers are included in this pull request.
Additionally these methods need to be added to config.yml of TheGaffers. No other changes are needed in TheGaffer and Architect.
